### PR TITLE
Bugfix/return type wrong type hint in polygon list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cwapi3d"
-version = "32.443.0"
+version = "32.443.1"
 authors = [{ name = "Cadwork", email = "it@cadwork.ca" }]
 requires-python = ">= 3.12"
 description = 'Python bindings for CwAPI3D'

--- a/src/cadwork/polygon_list.pyi
+++ b/src/cadwork/polygon_list.pyi
@@ -1,21 +1,20 @@
-from cadwork import point_3d
+from cadwork import vertex_list
+
 
 class polygon_list:
-    
+
     def count(self) -> int:
         """count
 
-        Returns:
-            int
+        Returns: int
         """
 
-    def at(self, index: int) -> point_3d:
+    def at(self, index: int) -> vertex_list:
         """at
 
         Parameters:
             index: index
 
         Returns:
-            point_3d
+            vertex_list: vertex_list
         """
-

--- a/src/cadwork/polygon_list.pyi
+++ b/src/cadwork/polygon_list.pyi
@@ -4,17 +4,17 @@ from cadwork import vertex_list
 class polygon_list:
 
     def count(self) -> int:
-        """count
+        """Returns the number of polygons in the list.
 
         Returns: int
         """
 
     def at(self, index: int) -> vertex_list:
-        """at
+        """Returns the polygon vertices at the given index.
 
         Parameters:
-            index: index
+            index: The zero-based polygon index.
 
         Returns:
-            vertex_list: vertex_list
+            vertex_list: The ordered vertices defining the polygon.
         """


### PR DESCRIPTION
`polygon_list.at(idx)` returns a `vertex_list` object and not a `point_3d`